### PR TITLE
Update tqdm to address security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 clickhouse_connect==0.6.8
 docker_py==1.10.6
 SQLAlchemy==1.4.32
-tqdm==4.63.0
+tqdm==4.66.3
 requests
 pyyaml
 psycopg2-binary

--- a/requirements/clickhouse_handler_requirements.txt
+++ b/requirements/clickhouse_handler_requirements.txt
@@ -1,4 +1,4 @@
-tqdm==4.63.0
+tqdm==4.66.3
 requests
 pyyaml
 clickhouse_connect==0.6.8

--- a/requirements/postgresql_handler_requirements.txt
+++ b/requirements/postgresql_handler_requirements.txt
@@ -1,4 +1,4 @@
-tqdm==4.63.0
+tqdm==4.66.3
 requests
 pyyaml
 psycopg2-binary

--- a/requirements/sql_handler_requirements.txt
+++ b/requirements/sql_handler_requirements.txt
@@ -1,4 +1,4 @@
-tqdm==4.63.0
+tqdm==4.66.3
 requests
 pyyaml
 pymysql


### PR DESCRIPTION
## Summary
- bump tqdm version to 4.66.3 in all requirements files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849c4fb1afc832ca25a47cc8c9c12fb